### PR TITLE
Corrected hard-coded dimension use and comments.

### DIFF
--- a/src/subset_tools.jl
+++ b/src/subset_tools.jl
@@ -161,10 +161,10 @@ end
 
 Overloading ∈ operator to check if a point is inside a subset of space.
 
-If the subset is 0-dimensional, all points are searched. If the subset is 1-dimensional,
+If the subset is 1-dimensional, all points are searched. If the subset is 2-dimensional,
 it is checked if the point is within the enclosed area. It is assumed that a
-1-dimensional subset used in such a context will form a closed area. If the subset is
-2-dimensional, its boundary is calculated on the fly. If used multiple times, it is
+2-dimensional subset used in such a context will form a closed area. If the subset is
+3-dimensional, its boundary is calculated on the fly. If used multiple times, it is
 recommended to calculate the boundary once and store it in a variable.
 """
 function Base.:∈(
@@ -179,12 +179,12 @@ function Base.:∈(
     dim = subset.element[1].object[1].dimension
     nodes = space.objects_per_dimension[1].object
     edges = space.objects_per_dimension[2].object
-    if dim == 2
+    if dim == 3
         subset_bnd = OMAS.edge_profiles__grid_ggd___grid_subset()
         subset_bnd.element = get_subset_boundary(space, subset)
-    elseif dim == 1
+    elseif dim == 2
         subset_bnd = subset
-    elseif dim == 0
+    elseif dim == 1
         for ele ∈ subset.element
             node = nodes[ele.object[1].index]
             if node.geometry[1] == r && node.geometry[2] == z


### PR DESCRIPTION
This is completing task 5 for issue https://github.com/ProjectTorreyPines/SOLPS2IMAS.jl/issues/16

Dimension definitions always count the toroidal dimension as well. Thus nodes in our SOLPS mesh are 1D rings around the toroid, edges are 2D surfaces along the toroid, and cells are 3D volume tubes around the toroid.

At GGDUtils, only the project_prop_on_subset! needed to be updated as it used hard-coded dimension number check for taking a course of action. Apart from this, some comments have been updated as well.

Tasks 1-4 of issue https://github.com/ProjectTorreyPines/SOLPS2IMAS.jl/issues/16 is completed in sister PR https://github.com/ProjectTorreyPines/SOLPS2IMAS.jl/pull/17

Both SOLPS2IMAS and GGDUtils are passing all tests with the two updated.