### PR TITLE
Moving grid_subset functions from SOLPS2IMAS

### DIFF
--- a/src/subset_tools.jl
+++ b/src/subset_tools.jl
@@ -1,4 +1,193 @@
-import SOLPS2IMAS: get_subset_space, get_grid_subset_with_index, get_subset_boundary
+"""
+    add_subset_element!(
+    subset::OMAS.edge_profiles__grid_ggd___grid_subset,
+    sn::Int,
+    dim::Int,
+    index::Int,
+    in_subset=(x...) -> true;
+    kwargs...,
+
+)
+
+Adds a new element to gird_subset with properties space number (sn), dimension (dim),
+and index (index). The element is added only if the function in_subset returns true.
+"""
+function add_subset_element!(
+    subset::OMAS.edge_profiles__grid_ggd___grid_subset,
+    sn::Int,
+    dim::Int,
+    index::Int,
+    in_subset=(x...) -> true;
+    kwargs...,
+)
+    if in_subset(; kwargs...)
+        dd_ind = length(subset.element) + 1
+        resize!(subset.element, dd_ind)
+        resize!(subset.element[dd_ind].object, 1)
+        subset.element[dd_ind].object[1].space = sn
+        subset.element[dd_ind].object[1].dimension = dim
+        subset.element[dd_ind].object[1].index = index
+    end
+end
+
+"""
+    add_subset_element!(
+    subset,
+    sn,
+    dim,
+    index::Vector{Int},
+    in_subset=(x...) -> true;
+    kwargs...,
+
+)
+
+Overloaded to work differently (faster) with list of indices to be added.
+"""
+function add_subset_element!(
+    subset::OMAS.edge_profiles__grid_ggd___grid_subset,
+    sn::Int,
+    dim::Int,
+    index::Vector{Int},
+    in_subset=(x...) -> true;
+    kwargs...,
+)
+    if in_subset(; kwargs...)
+        dd_start_ind = length(subset.element) + 1
+        resize!(subset.element, length(subset.element) + length(index))
+        dd_stop_ind = length(subset.element)
+        for (ii, dd_ind) ∈ enumerate(dd_start_ind:dd_stop_ind)
+            resize!(subset.element[dd_ind].object, 1)
+            subset.element[dd_ind].object[1].space = sn
+            subset.element[dd_ind].object[1].dimension = dim
+            subset.element[dd_ind].object[1].index = index[ii]
+        end
+    end
+end
+
+"""
+    get_subset_space(space::OMAS.edge_profiles__grid_ggd___space,
+    elements::Vector{OMAS.edge_profiles__grid_ggd___grid_subset___element})
+
+Returns an array of space object indices corresponding to the correct
+objects_per_dimension (nodes, edges or cells) for the subset elements.
+"""
+function get_subset_space(space::OMAS.edge_profiles__grid_ggd___space,
+    elements::Vector{OMAS.edge_profiles__grid_ggd___grid_subset___element})
+    nD = elements[1].object[1].dimension
+    nD_objects = space.objects_per_dimension[nD].object
+    return [nD_objects[ele.object[1].index] for ele ∈ elements]
+end
+
+"""
+    get_grid_subset_with_index(
+    grid_ggd::OMAS.edge_profiles__grid_ggd,
+    grid_subset_index::Int,
+
+)
+
+Returns the grid_subset in a grid_ggd with the matching grid_subset_index
+"""
+function get_grid_subset_with_index(
+    grid_ggd::OMAS.edge_profiles__grid_ggd,
+    grid_subset_index::Int,
+)
+    for subset ∈ grid_ggd.grid_subset
+        if subset.identifier.index == grid_subset_index
+            return subset
+        end
+    end
+    return 0  # Indicates failure
+end
+
+"""
+    get_subset_boundary_inds(
+    space::OMAS.edge_profiles__grid_ggd___space,
+    subset::OMAS.edge_profiles__grid_ggd___grid_subset,
+
+)
+
+Returns an array of space object indices corresponding to the boundary of the subset.
+That means, it returns indices of nodes that are at the end of open edge subset or
+it returns the indices of edges that are the the boundary of a cell subset.
+Returns an empty array if the subset is 1D (nodes).
+"""
+function get_subset_boundary_inds(
+    space::OMAS.edge_profiles__grid_ggd___space,
+    subset::OMAS.edge_profiles__grid_ggd___grid_subset,
+)
+    nD = subset.element[1].object[1].dimension
+    if nD > 1  # Only 2D (edges) and 3D (cells) subsets have boundaries
+        nD_objects = space.objects_per_dimension[nD].object
+        elements = [nD_objects[ele.object[1].index] for ele ∈ subset.element]
+        boundary_inds = Int[]
+        for ele ∈ elements
+            symdiff!(boundary_inds, [bnd.index for bnd ∈ ele.boundary])
+        end
+        return boundary_inds
+    end
+    return [] # 1D (nodes) subsets have no boundary
+end
+
+"""
+    get_subset_boundary(
+    space::OMAS.edge_profiles__grid_ggd___space,
+    subset::OMAS.edge_profiles__grid_ggd___grid_subset,
+
+)
+
+Returns an array of elements of grid_subset generated from the boundary of the subset
+provided. The dimension of these elments is reduced by 1.
+"""
+function get_subset_boundary(
+    space::OMAS.edge_profiles__grid_ggd___space,
+    subset::OMAS.edge_profiles__grid_ggd___grid_subset,
+)
+    ret_subset = OMAS.edge_profiles__grid_ggd___grid_subset()
+    boundary_inds = get_subset_boundary_inds(space, subset)
+    bnd_dim = subset.element[1].object[1].dimension - 1
+    space_number = subset.element[1].object[1].space
+    add_subset_element!(ret_subset, space_number, bnd_dim, boundary_inds)
+    return ret_subset.element
+end
+
+"""
+    subset_do(set_operator,
+    itrs::Vararg{Vector{OMAS.edge_profiles__grid_ggd___grid_subset___element}};
+    space::OMAS.edge_profiles__grid_ggd___space=OMAS.edge_profiles__grid_ggd___space(),
+    use_nodes=false)
+
+Function to perform any set operation (intersect, union, setdiff etc.) on
+subset.element to generate a list of elements to go to subset object. If use_nodes is
+true, the set operation will be applied on the set of nodes from subset.element, space
+argument is required for this.
+Note: that the arguments are subset.element (not the subset itself). Similarly, the
+return object is a list of OMAS.edge_profiles__grid_ggd___grid_subset___element.
+"""
+function subset_do(set_operator,
+    itrs::Vararg{Vector{OMAS.edge_profiles__grid_ggd___grid_subset___element}};
+    space::OMAS.edge_profiles__grid_ggd___space=OMAS.edge_profiles__grid_ggd___space(),
+    use_nodes=false)
+    if use_nodes
+        ele_inds = set_operator(
+            [
+                union([
+                        obj.nodes for obj ∈ get_subset_space(space, set_elements)
+                    ]...
+                ) for set_elements ∈ itrs
+            ]...,
+        )
+        dim = 1
+    else
+        ele_inds = set_operator(
+            [[ele.object[1].index for ele ∈ set_elements] for set_elements ∈ itrs]...,
+        )
+        dim = itrs[1][1].object[1].dimension
+    end
+    ret_subset = OMAS.edge_profiles__grid_ggd___grid_subset()
+    space_number = itrs[1][1].object[1].space
+    add_subset_element!(ret_subset, space_number, dim, ele_inds)
+    return ret_subset.element
+end
 
 """
     get_subset_centers(space::OMAS.edge_profiles__grid_ggd___space,
@@ -8,7 +197,8 @@ Returns an array of tuples corresponding to (r,z) coordinates of the center of
 cells or the center of edges in the subset space.
 """
 function get_subset_centers(space::OMAS.edge_profiles__grid_ggd___space,
-    subset::OMAS.edge_profiles__grid_ggd___grid_subset)
+    subset::OMAS.edge_profiles__grid_ggd___grid_subset,
+)
     subset_space = get_subset_space(space, subset.element)
     grid_nodes = space.objects_per_dimension[1].object
     return [
@@ -64,7 +254,7 @@ function project_prop_on_subset!(prop_arr::Vector{T},
     to_subset::OMAS.edge_profiles__grid_ggd___grid_subset,
     space::OMAS.edge_profiles__grid_ggd___space,
     value_field::Symbol=:values;
-    interp_method=:thin_plate_spline,
+    interp_method::Symbol=:thin_plate_spline,
     interp_kwargs=Dict(),
 ) where {T <: edge_profiles__prop_on_subset}
     if from_subset.element[1].object[1].dimension ==

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
-import GGDUtils: interp, get_kdtree, project_prop_on_subset!
+import GGDUtils: interp, get_kdtree, project_prop_on_subset!, get_grid_subset_with_index
 import OMAS: h5i2imas
 import Statistics: mean
-import SOLPS2IMAS: solps2imas, get_grid_subset_with_index
+import SOLPS2IMAS: solps2imas
 using Test
 using ArgParse: ArgParse
 


### PR DESCRIPTION
Following new functions are being added to the subset_tools.jl file:

- add_subset_element!
- get_subset_space
- get_grid_subset_with_index
- get_subset_boundary_inds
- get_subset_boundary
- subset_do

These functions have been modified to have fixed input argument types. Currently, most grid_subset operations are only defined for edge profiles but this can be expanded easily using get_types_with() from types.jl.

## Dependence

In principle, this removes all dependence of GGDUtils from SOLPS2IMAS.

However, for the test script, we still need to use SOLPS2IMAS to load a sample file. 
The test package dependencies is a big issue in julia. You can either keep supporting "] test" functionality of Julia package manager or be able to use the runtests.jl standalone, but not both. I would like to keep the latter option but we should be compatible with julia's test command too. I'll fix this issue later maybe.

One good way of fixing it is to import an edge_profiles file with electron density and temperature data. We could generate a json file using OMAS.json2imas but it turned out this function is failing. See issue https://github.com/ProjectTorreyPines/OMAS.jl/issues/9. This also brought up the case for having a h5 writing function in OMAS.jl (see issue https://github.com/ProjectTorreyPines/OMAS.jl/issues/10) so that we can pass around h5 file after loading edge_profiles data.