### PR TITLE
Quick bug fix while plotting subset with cells

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -51,8 +51,8 @@ end
     label_assigned = false
     if subset.element[1].object[1].dimension == 3
         for ele ∈ subset.element
-            for bnd_ind ∈ cells[ele.object[1].index].boundary
-                union!(subset_edge_inds, bnd_ind)
+            for bnd ∈ cells[ele.object[1].index].boundary
+                union!(subset_edge_inds, bnd.index)
             end
         end
     elseif subset.element[1].object[1].dimension == 2


### PR DESCRIPTION
A small bug that would have not allowed plotting subsets that contains cells instead of edges. Somehow this was missed in all the testing so far, but it is a relatively simple and small fix. So will merge without review.