### PR TITLE
Added Compat and CompatHelper CI

### DIFF
--- a/.github/workflows/compat_helper.yml
+++ b/.github/workflows/compat_helper.yml
@@ -1,0 +1,26 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: '37 3 * * *'
+  workflow_dispatch:
+  push:
+    branches:
+      - compat
+
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Add the FuseRegistry via Git"
+        run: |
+          using Pkg
+          Pkg.Registry.add(RegistrySpec(url="https://github.com/ProjectTorreyPines/FuseRegistry.jl.git"))
+          Pkg.Registry.add("General")
+        shell: julia --color=yes {0}
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia -e 'using CompatHelper; CompatHelper.main(;master_branch="compat")'

--- a/.github/workflows/compat_helper.yml
+++ b/.github/workflows/compat_helper.yml
@@ -3,16 +3,6 @@ on:
   schedule:
     - cron: '37 3 * * *'
   workflow_dispatch:
-  pull_request:
-    branches:
-      - dev
-    paths:
-      - 'Project.toml'
-  push:
-    branches:
-      - dev
-    paths:
-      - 'Project.toml'
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest

--- a/.github/workflows/compat_helper.yml
+++ b/.github/workflows/compat_helper.yml
@@ -3,10 +3,16 @@ on:
   schedule:
     - cron: '37 3 * * *'
   workflow_dispatch:
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - 'Project.toml'
   push:
     branches:
-      - compat
-
+      - dev
+    paths:
+      - 'Project.toml'
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
@@ -23,4 +29,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main(;master_branch="compat")'
+        run: julia -e 'using CompatHelper; CompatHelper.main(;master_branch="dev", pr_title_prefix="[ci skip] ")'

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -3,15 +3,21 @@ name: Format Check
 on:
   push:
     branches: ["master", "dev", "format"]
+    paths:
+      - '.github/workflows/format_check.yml'
+      - '**.jl'
   pull_request:
     branches: ["master", "dev"]
+    paths:
+      - '.github/workflows/format_check.yml'
+      - '**.jl'
 jobs:
   check:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.9.3]
-        julia-arch: [x86]
+        julia-version: [1.x]
+        julia-arch: [x64]
         os: [ubuntu-latest]
     steps:
       - uses: julia-actions/setup-julia@latest
@@ -23,6 +29,7 @@ jobs:
         run: |
           julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
           julia  -e 'using JuliaFormatter; format(".", verbose=true)'
+      - uses: julia-actions/cache@v1
       - name: Format check
         run: |
           julia -e '

--- a/.github/workflows/make_docs.yml
+++ b/.github/workflows/make_docs.yml
@@ -34,9 +34,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
       - uses: julia-actions/cache@v1
+      - name: "Add the FuseRegistry via Git"
+        run: |
+          julia --project=docs/ -e 'using Pkg; Pkg.Registry.add(RegistrySpec(url="https://github.com/ProjectTorreyPines/FuseRegistry.jl.git")); Pkg.Registry.add("General")'
       - name: Install dependencies
         run: |
-          julia --project=docs/ -e 'using Pkg; Pkg.add(; url="https://github.com/ProjectTorreyPines/IMASDD.jl.git"); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+          julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/make_docs.yml
+++ b/.github/workflows/make_docs.yml
@@ -1,7 +1,11 @@
 name: Make Docs
 on:
   pull_request:
-    branches: ["master"]
+    branches: ["master", "dev"]
+    paths:
+      - '.github/workflows/make_docs.yml'
+      - 'src/**'
+      - 'docs/**'
   push:
     branches:
       - master
@@ -9,7 +13,7 @@ on:
       - docs
     paths:
       - '.github/workflows/make_docs.yml'
-      - 'src/'
+      - 'src/**'
       - 'docs/**'
     tags: '*'
   workflow_dispatch:
@@ -20,7 +24,12 @@ jobs:
       contents: write
       statuses: write
     name: Documentation
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1.x]
+        julia-arch: [x64]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,15 +3,25 @@ name: Test
 on:
   push:
     branches: ["master", "dev", "autotest"]
+    paths:
+      - '.github/workflows/test.yml'
+      - 'src/**'
+      - 'test/**'
+      - 'Project.toml'
   pull_request:
     branches: ["master", "dev"]
+    paths:
+      - '.github/workflows/test.yml'
+      - 'src/**'
+      - 'test/**'
+      - 'Project.toml'
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.9.3]
-        julia-arch: [x86]
+        julia-version: [1.x]
+        julia-arch: [x64]
         os: [ubuntu-latest]
     steps:
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,11 @@ on:
       - 'src/**'
       - 'test/**'
       - 'Project.toml'
+
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -42,9 +47,9 @@ jobs:
         run: |
           dvc pull
       - uses: julia-actions/cache@v1
-      - name: Install dependencies
+      - name: "Add the FuseRegistry via Git"
         run: |
-          julia --project=. -e 'using Pkg; Pkg.rm(["IMASDD"]); Pkg.add(url="git@github.com:ProjectTorreyPines/IMASDD.jl.git", rev="master")'
+          julia --project=. -e 'using Pkg; Pkg.Registry.add(RegistrySpec(url="https://github.com/ProjectTorreyPines/FuseRegistry.jl.git")); Pkg.Registry.add("General")'
       - uses: julia-actions/julia-runtest@v1
       # Not set up yet
       # - uses: julia-actions/julia-processcoverage@v1

--- a/Project.toml
+++ b/Project.toml
@@ -13,3 +13,6 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+RecipesBase = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -15,4 +15,12 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+ArgParse = "1"
+ColorSchemes = "3"
+IMASDD = "0.1"
+Interpolations = "0.15"
+NearestNeighbors = "0.4"
 RecipesBase = "1"
+StaticArrays = "1"
+Statistics = "1"
+julia = ">= 1.10"


### PR DESCRIPTION
Compat section has been added to Project.toml using CompatHelper CI. The CI will now run every day at 3:37 UTC to check for updates on dependencies. Whenever a change is required, the CI will send PR to the dev branch where tests will be performed. If the CompatHelper PR is accepted, it can be further sent to merge with the master by updating the version number and releasing the new tag.

This PR also fixes paths, julia version numbers, and installation registry for other CI tests. 