### PR TITLE
Using use_existing_registries

### DIFF
--- a/.github/workflows/compat_helper.yml
+++ b/.github/workflows/compat_helper.yml
@@ -19,4 +19,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main(;master_branch="dev", pr_title_prefix="[ci skip] ")'
+        run: julia -e 'using CompatHelper; CompatHelper.main(;master_branch="dev", use_existing_registries=true)'


### PR DESCRIPTION
Trying use of use_existing_registries keyword to get FuseRegistry for CompatHelper. Directly merging with master to see the effect. If works, dev will be rebased to updated master.