### PR TITLE
Expanding acces of functions to all grid_ggd

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IMASggd"
 uuid = "b7b5e640-9b39-4803-84eb-376048795def"
 authors = ["Anchal Gupta <guptaa@fusion.gat.com>"]
-version = "2.0.1"
+version = "3.0.0"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
@@ -17,7 +17,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 ArgParse = "1"
 ColorSchemes = "3"
-IMASdd = "2, 3"
+IMASdd = "2, 3, 4"
 Interpolations = "0.15"
 NearestNeighbors = "0.4"
 RecipesBase = "1"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -49,14 +49,24 @@ get_prop_with_grid_subset_index
 get_types_with
 ```
 
+This function has been used to create following types that are used in this module and
+can be imported for further use.
+
+```@docs
+IMASggd.all__grid_ggd
+IMASggd.all__space
+IMASggd.all__grid_subset
+IMASggd.all__grid_subset_prop
+```
+
 ## Plot recipes
 
 Several plot recipes have been defined for easy visualization.
 ```@docs
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::IMASggd.IMASdd.edge_profiles__grid_ggd___space)
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::IMASggd.IMASdd.edge_profiles__grid_ggd___space, ::IMASggd.IMASdd.edge_profiles__grid_ggd___grid_subset)
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::IMASggd.IMASdd.edge_profiles__grid_ggd, ::IMASggd.IMASdd.IDSvectorElement)
-RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractVector{<:IMASggd.IMASdd.edge_profiles__grid_ggd}, ::IMASggd.IMASdd.IDSvectorElement)
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::IMASggd.all__space)
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::IMASggd.all__space, ::IMASggd.all__grid_subset)
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::IMASggd.all__grid_ggd, ::IMASggd.all__grid_subset_prop)
+RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::AbstractVector{<:IMASggd.all__grid_ggd}, ::IMASggd.all__grid_subset_prop)
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::IMASggd.IMASdd.interferometer)
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::IMASggd.IMASdd.interferometer__channel)
 RecipesBase.apply_recipe(::Dict{Symbol,Any}, ::IMASggd.IMASdd.interferometer__channel___line_of_sight)

--- a/examples/plotting.ipynb
+++ b/examples/plotting.ipynb
@@ -24,7 +24,6 @@
          "source": [
             "using Pkg\n",
             "Pkg.activate(\"./\")\n",
-            "Pkg.add(url=\"git@github.com:ProjectTorreyPines/IMASdd.jl.git\")\n",
             "Pkg.develop(path=\"../\")\n",
             "Pkg.add(\"Plots\")\n",
             "Pkg.add(\"LaTeXStrings\")"
@@ -32,7 +31,7 @@
       },
       {
          "cell_type": "code",
-         "execution_count": null,
+         "execution_count": 2,
          "metadata": {},
          "outputs": [],
          "source": [
@@ -44,7 +43,7 @@
       },
       {
          "cell_type": "code",
-         "execution_count": null,
+         "execution_count": 3,
          "metadata": {},
          "outputs": [],
          "source": [
@@ -115,7 +114,7 @@
             "gr()           # Fast and can save pdf\n",
             "# plotlyjs()   # Use for interactive plot, can only save png\n",
             "\n",
-            "n_e = IMASggd.get_prop_with_grid_subset_index(dd.edge_profiles.ggd[1].electrons.density, 5)\n",
+            "n_e = IMASggd.get_prop_with_grid_subset_index(dd.edge_profiles.ggd[1].electrons.density, -5)\n",
             "plot(dd.edge_profiles.grid_ggd, n_e, colorbar_title=\"Electrons density / \" * L\"m^{-3}\",\n",
             "     left_margin=10Plots.pt)"
          ]
@@ -146,15 +145,15 @@
    ],
    "metadata": {
       "kernelspec": {
-         "display_name": "Julia 1.9.2",
+         "display_name": "Julia 1.10.4",
          "language": "julia",
-         "name": "julia-1.9"
+         "name": "julia-1.10"
       },
       "language_info": {
          "file_extension": ".jl",
          "mimetype": "application/julia",
          "name": "julia",
-         "version": "1.9.2"
+         "version": "1.10.4"
       },
       "orig_nbformat": 4
    },

--- a/examples/plotting_interferometer.ipynb
+++ b/examples/plotting_interferometer.ipynb
@@ -24,14 +24,13 @@
             "source": [
                 "using Pkg\n",
                 "Pkg.activate(\"./\")\n",
-                "Pkg.add(url=\"git@github.com:ProjectTorreyPines/IMASdd.jl.git\")\n",
-                "Pkg.develop(path=\"../\")\n",
-                "Pkg.add(\"Plots\")"
+                "# Pkg.develop(path=\"../\")\n",
+                "# Pkg.add(\"Plots\")"
             ]
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "execution_count": 2,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -49,7 +48,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "execution_count": 3,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -217,7 +216,7 @@
             "source": [
                 "gr()\n",
                 "\n",
-                "n_e = IMASggd.get_prop_with_grid_subset_index(ids.edge_profiles.ggd[1].electrons.density, 5)\n",
+                "n_e = IMASggd.get_prop_with_grid_subset_index(ids.edge_profiles.ggd[1].electrons.density, -5)\n",
                 "plot(ids.edge_profiles.grid_ggd, n_e, colorbar_title=\"Electrons density / m^(-3)\", left_margin=10Plots.pt)\n",
                 "plot!(space)\n",
                 "plot!(ids.interferometer, legend=true, size=[635, 900]) # Adding a size comment to make plot aspect ratio better"
@@ -226,15 +225,15 @@
     ],
     "metadata": {
         "kernelspec": {
-            "display_name": "Julia 1.9.2",
+            "display_name": "Julia 1.10.4",
             "language": "julia",
-            "name": "julia-1.9"
+            "name": "julia-1.10"
         },
         "language_info": {
             "file_extension": ".jl",
             "mimetype": "application/julia",
             "name": "julia",
-            "version": "1.9.2"
+            "version": "1.10.4"
         },
         "orig_nbformat": 4
     },

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -8,11 +8,11 @@ export get_kdtree
 export get_TPS_mats
 
 """
-    get_kdtree(space::IMASdd.edge_profiles__grid_ggd___space)
+    get_kdtree(space::all__space)
 
 Get a KDTree for all the cells in the space for search for nearest neighbours.
 """
-function get_kdtree(space::IMASdd.edge_profiles__grid_ggd___space)
+function get_kdtree(space::all__space)
     grid_nodes = space.objects_per_dimension[1].object
     grid_faces = space.objects_per_dimension[3].object
     grid_faces = [cell for cell ∈ grid_faces if length(cell.nodes) == 4]
@@ -25,15 +25,15 @@ end
 
 """
     get_kdtree(
-        space::IMASdd.edge_profiles__grid_ggd___space,
-        subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
+        space::all__space,
+        subset::all__grid_subset,
     )
 
 Get a KDTree for a subset of the space for search for nearest neighbours.
 """
 function get_kdtree(
-    space::IMASdd.edge_profiles__grid_ggd___space,
-    subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
+    space::all__space,
+    subset::all__grid_subset,
 )
     subset_centers = get_subset_centers(space, subset)
     return KDTree([SVector{2}(sc) for sc ∈ subset_centers]; leafsize=10)
@@ -178,7 +178,7 @@ function interp(y::Vector{T}, x::Vector{Tuple{U, U}}) where {T <: Real, U <: Rea
     return interp(y, get_TPS_mats(x))
 end
 
-function get_TPS_mats(space::IMASdd.edge_profiles__grid_ggd___space)
+function get_TPS_mats(space::all__space)
     nodes = [Tuple(node.geometry) for node ∈ space.objects_per_dimension[1].object]
     return get_TPS_mats(nodes)
 end
@@ -186,7 +186,7 @@ end
 """
     interp(
         prop_values::Vector{T},
-        space::IMASdd.edge_profiles__grid_ggd___space
+        space::all__space
     ) where {T <: Real}
 
 If the whole space is provided instead of a kdtree, calculate the kdtree for whole
@@ -195,14 +195,14 @@ of the space.
 """
 function interp(
     prop_values::Vector{T},
-    space::IMASdd.edge_profiles__grid_ggd___space,
+    space::all__space,
 ) where {T <: Real}
     return interp(prop_values, get_TPS_mats(space))
 end
 
 function get_TPS_mats(
-    space::IMASdd.edge_profiles__grid_ggd___space,
-    subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
+    space::all__space,
+    subset::all__grid_subset,
 )
     return get_TPS_mats(get_subset_centers(space, subset))
 end
@@ -210,8 +210,8 @@ end
 """
     interp(
         prop_values::Vector{Real},
-        space::IMASdd.edge_profiles__grid_ggd___space,
-        subset::IMASdd.edge_profiles__grid_ggd___grid_subset
+        space::all__space,
+        subset::all__grid_subset
     )
 
 If a subset of the space is provided, calculate the kdtree for the subset. In this case
@@ -219,16 +219,16 @@ it is assumed that the property values are provided for each element of the subs
 """
 function interp(
     prop_values::Vector{T},
-    space::IMASdd.edge_profiles__grid_ggd___space,
-    subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
+    space::all__space,
+    subset::all__grid_subset,
 ) where {T <: Real}
     return interp(prop_values, get_TPS_mats(space, subset))
 end
 
 """
     interp(
-        prop::edge_profiles__prop_on_subset,
-        grid_ggd::IMASdd.edge_profiles__grid_ggd,
+        prop::all__grid_subset_prop,
+        grid_ggd::all__grid_ggd,
         value_field::Symbol=:values
     )
 
@@ -241,8 +241,8 @@ get_e_field_par = interp(dd.edge_profiles.ggd[1].e_field[1], grid_ggd, :parallel
 ```
 """
 function interp(
-    prop::edge_profiles__prop_on_subset,
-    grid_ggd::IMASdd.edge_profiles__grid_ggd,
+    prop::all__grid_subset_prop,
+    grid_ggd::all__grid_ggd,
     value_field::Symbol=:values,
 )
     subset = get_grid_subset(grid_ggd, prop.grid_subset_index)
@@ -253,10 +253,10 @@ end
 """
     interp(
         prop_arr::AbstractVector{T},
-        space::IMASdd.edge_profiles__grid_ggd___space,
-        subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
+        space::all__space,
+        subset::all__grid_subset,
         value_field::Symbol=:values
-    ) where {T <: edge_profiles__prop_on_subset}
+    ) where {T <: all__grid_subset_prop}
 
 Example:
 
@@ -267,10 +267,10 @@ get_electron_density = interp(dd.edge_profiles.ggd[1].electrons.density, space, 
 """
 function interp(
     prop_arr::AbstractVector{T},
-    space::IMASdd.edge_profiles__grid_ggd___space,
-    subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
+    space::all__space,
+    subset::all__grid_subset,
     value_field::Symbol=:values,
-) where {T <: edge_profiles__prop_on_subset}
+) where {T <: all__grid_subset_prop}
     prop = get_prop_with_grid_subset_index(prop_arr, subset.identifier.index)
     return interp(getfield(prop, value_field), space, subset)
 end
@@ -278,10 +278,10 @@ end
 """
     interp(
         prop_arr::AbstractVector{T},
-        grid_ggd::IMASdd.edge_profiles__grid_ggd,
+        grid_ggd::all__grid_ggd,
         grid_subset_index::Int,
         value_field::Symbol=:values
-    ) where {T <: edge_profiles__prop_on_subset}
+    ) where {T <: all__grid_subset_prop}
 
 Example:
 
@@ -291,17 +291,17 @@ get_n_e_sep = interp(dd.edge_profiles.ggd[1].electrons.density, grid_ggd, 16)
 """
 function interp(
     prop_arr::AbstractVector{T},
-    grid_ggd::IMASdd.edge_profiles__grid_ggd,
+    grid_ggd::all__grid_ggd,
     grid_subset_index::Int,
     value_field::Symbol=:values,
-) where {T <: edge_profiles__prop_on_subset}
+) where {T <: all__grid_subset_prop}
     prop = get_prop_with_grid_subset_index(prop_arr, grid_subset_index)
     subset = get_grid_subset(grid_ggd, grid_subset_index)
     space = grid_ggd.space[subset.element[1].object[1].space]
     return interp(getfield(prop, value_field), space, subset)
 end
 
-function get_TPS_mats(grid_ggd::IMASdd.edge_profiles__grid_ggd, grid_subset_index::Int)
+function get_TPS_mats(grid_ggd::all__grid_ggd, grid_subset_index::Int)
     subset = get_grid_subset(grid_ggd, grid_subset_index)
     space = grid_ggd.space[subset.element[1].object[1].space]
     return get_TPS_mats(space, subset)
@@ -313,7 +313,7 @@ end
         TPS_mats::Tuple{Matrix{U}, Matrix{U}, Matrix{U}, Vector{Tuple{U, U}}},
         grid_subset_index::Int,
         value_field::Val{V}=Val(:values),
-    ) where {T <: edge_profiles__prop_on_subset, U <: Real, V}
+    ) where {T <: all__grid_subset_prop, U <: Real, V}
 
 Same use case as above but allows one to reuse previously calculated TPS matrices.
 
@@ -335,7 +335,7 @@ function interp(
     TPS_mats::Tuple{Matrix{U}, Matrix{U}, Matrix{U}, Vector{Tuple{U, U}}},
     grid_subset_index::Int,
     value_field::Val{V}=Val(:values),
-) where {T <: edge_profiles__prop_on_subset, U <: Real, V}
+) where {T <: all__grid_subset_prop, U <: Real, V}
     prop = get_prop_with_grid_subset_index(prop_arr, grid_subset_index)
     field = getfield(prop, V)
     return interp(field, TPS_mats)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -3,12 +3,12 @@ using ColorSchemes: ColorSchemes
 import Statistics: norm, dot
 
 """
-    plot(space::IMASdd.edge_profiles__grid_ggd___space)
+    plot(space::all__space)
 
 Plot the grid_ggd space object. Defaults to size of [600, 900] and linecolor of :black,
 linewidth of 0.2, and no legend.
 """
-@recipe function f(space::IMASdd.edge_profiles__grid_ggd___space)
+@recipe function f(space::all__space)
     nodes = space.objects_per_dimension[1].object
     edges = space.objects_per_dimension[2].object
     legend --> false
@@ -40,18 +40,12 @@ linewidth of 0.2, and no legend.
 end
 
 """
-    plot(
-        space::IMASdd.edge_profiles__grid_ggd___space,
-        subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
-    )
+    plot(space::all__space, subset::all__grid_subset)
 
 Plot the a subset of a space. Defaults to size of [600, 900] and linecolor of :black,
 linewidth of 0.2, and no legend.
 """
-@recipe function f(
-    space::IMASdd.edge_profiles__grid_ggd___space,
-    subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
-)
+@recipe function f(space::all__space, subset::all__grid_subset)
     nodes = space.objects_per_dimension[1].object
     edges = space.objects_per_dimension[2].object
     cells = space.objects_per_dimension[3].object
@@ -115,10 +109,7 @@ linewidth of 0.2, and no legend.
 end
 
 """
-    plot(
-        grid_ggd::IMASdd.edge_profiles__grid_ggd,
-        prop::IMASdd.IDSvectorElement,
-    )
+    plot(grid_ggd::all__grid_ggd, prop::all__grid_subset_prop)
 
 Plot 2D heatmap of edge_profiles_ggd property on a grid_ggd space object. Defaults to
 size of [635, 900], xaxis of "R / m", yaxis of "Z / m", and no legend. If :seriescolor
@@ -126,10 +117,7 @@ is not provided, :inferno color scheme is used. If :colorbar_title is not provid
 property name is used. This function creates a plot with layout [a{0.95w} b] where a
 is the heatmap and b is the colorbar.
 """
-@recipe function f(
-    grid_ggd::IMASdd.edge_profiles__grid_ggd,
-    prop::IMASdd.IDSvectorElement,
-)
+@recipe function f(grid_ggd::all__grid_ggd, prop::all__grid_subset_prop)
     subset = get_grid_subset(grid_ggd, prop.grid_subset_index)
     space = grid_ggd.space[subset.element[1].object[1].space]
     nodes = space.objects_per_dimension[1].object
@@ -190,10 +178,7 @@ is the heatmap and b is the colorbar.
 end
 
 """
-    plot(
-        grid_ggd_arr::AbstractVector{<:IMASdd.edge_profiles__grid_ggd},
-        prop::IMASdd.IDSvectorElement,
-    )
+    plot(grid_ggd_arr::AbstractVector{<:all__grid_ggd}, prop::all__grid_subset_prop)
 
 Plot 2D heatmap of edge_profiles_ggd property on a grid_ggd space object. Defaults to
 size of [635, 900], xaxis of "R / m", yaxis of "Z / m", and no legend. If :seriescolor
@@ -202,8 +187,8 @@ property name is used. This function creates a plot with layout [a{0.95w} b] whe
 is the heatmap and b is the colorbar.
 """
 @recipe function f(
-    grid_ggd_arr::AbstractVector{<:IMASdd.edge_profiles__grid_ggd},
-    prop::IMASdd.IDSvectorElement,
+    grid_ggd_arr::AbstractVector{<:all__grid_ggd},
+    prop::all__grid_subset_prop,
 )
     found = false
     for grid_ggd ∈ grid_ggd_arr
@@ -222,9 +207,7 @@ is the heatmap and b is the colorbar.
 end
 
 """
-    plot(
-        ifo::IMASdd.interferometer,
-    )
+    plot(ifo::IMASdd.interferometer)
 
 Plot all the channels of interferometer object.
 Optional keywords:
@@ -246,9 +229,7 @@ Optional keywords:
     end
 
 """
-    plot(
-        ifo_ch::IMASdd.interferometer__channel,
-    )
+    plot(ifo_ch::IMASdd.interferometer__channel)
 
 Plot individual channel of interferometer.
 Optional keywords:
@@ -260,9 +241,7 @@ Optional keywords:
   - :mirror_length: 0.5(default).
   - :mirror_thickness: 0.1(default).
 """
-@recipe function f(
-    ifo_ch::IMASdd.interferometer__channel,
-)
+@recipe function f(ifo_ch::IMASdd.interferometer__channel)
     if :plot_type ∈ keys(plotattributes)
         plot_type = plotattributes[:plot_type]
     else
@@ -291,9 +270,7 @@ Optional keywords:
 end
 
 """
-    plot(
-        ifo_ch_los::IMASdd.interferometer__channel___line_of_sight,
-    )
+    plot(ifo_ch_los::IMASdd.interferometer__channel___line_of_sight)
 
 Plot line of sight of a channel of interferometer.
 
@@ -310,9 +287,7 @@ Optional keywords:
   - :mirror_length: 0.5(default).
   - :mirror_thickness: 0.1(default).
 """
-@recipe function f(
-    ifo_ch_los::IMASdd.interferometer__channel___line_of_sight,
-)
+@recipe function f(ifo_ch_los::IMASdd.interferometer__channel___line_of_sight)
     subplot --> 1
     size --> [600, 900]
     xaxis --> "R / m"
@@ -391,9 +366,7 @@ Optional keywords:
 end
 
 """
-    plot(
-        ifo_ch_n_e_line::IMASdd.interferometer__channel___n_e_line,
-    )
+    plot(ifo_ch_n_e_line::IMASdd.interferometer__channel___n_e_line)
 
 Plot line integrated electron density of a channel of interferometer.
 
@@ -407,9 +380,7 @@ Optional keywords:
 
   - :average: true or false(default). If true, plot the average n_e vs time.
 """
-@recipe function f(
-    ifo_ch_n_e_line::IMASdd.interferometer__channel___n_e_line,
-)
+@recipe function f(ifo_ch_n_e_line::IMASdd.interferometer__channel___n_e_line)
     if :average ∈ keys(plotattributes)
         @series begin
             ifo_ch.n_e_line_average
@@ -427,9 +398,7 @@ Optional keywords:
 end
 
 """
-    plot(
-        ifo_ch_n_e_line_average::IMASdd.interferometer__channel___n_e_line_average,
-    )
+    plot(ifo_ch_n_e_line_average::IMASdd.interferometer__channel___n_e_line_average)
 
 Plot average electron density of a channel of interferometer.
 

--- a/src/subset_tools.jl
+++ b/src/subset_tools.jl
@@ -11,7 +11,7 @@ export get_prop_with_grid_subset_index
 
 """
     add_subset_element!(
-        subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
+        subset::all__grid_subset,
         sn::Int,
         dim::Int,
         index::Int,
@@ -23,7 +23,7 @@ Adds a new element to gird_subset with properties space number (sn), dimension (
 and index (index). The element is added only if the function in_subset returns true.
 """
 function add_subset_element!(
-    subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
+    subset::all__grid_subset,
     sn::Int,
     dim::Int,
     index::Int,
@@ -42,9 +42,9 @@ end
 
 """
     add_subset_element!(
-        subset,
-        sn,
-        dim,
+        subset::all__grid_subset,
+        sn::Int,
+        dim::Int,
         index::Vector{Int},
         in_subset=(x...) -> true;
         kwargs...,
@@ -53,7 +53,7 @@ end
 Overloaded to work differently (faster) with list of indices to be added.
 """
 function add_subset_element!(
-    subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
+    subset::all__grid_subset,
     sn::Int,
     dim::Int,
     index::Vector{Int},
@@ -74,70 +74,50 @@ function add_subset_element!(
 end
 
 """
-    get_subset_space(
-        space::IMASdd.edge_profiles__grid_ggd___space,
-        elements::AbstractVector{<:IMASdd.edge_profiles__grid_ggd___grid_subset___element}
-    )
+    get_subset_space(space::all__space, subset::all__grid_subset)
 
 Returns an array of space object indices corresponding to the correct
 objects_per_dimension (nodes, edges or cells) for the subset elements.
 """
-function get_subset_space(
-    space::IMASdd.edge_profiles__grid_ggd___space,
-    elements::AbstractVector{<:IMASdd.edge_profiles__grid_ggd___grid_subset___element},
-)
-    nD = elements[1].object[1].dimension
+function get_subset_space(space::all__space, subset::all__grid_subset)
+    nD = subset.element[1].object[1].dimension
     nD_objects = space.objects_per_dimension[nD].object
-    return [nD_objects[ele.object[1].index] for ele ∈ elements]
+    return [nD_objects[ele.object[1].index] for ele ∈ subset.element]
 end
 
 """
-    get_grid_subset(
-        grid_ggd::IMASdd.edge_profiles__grid_ggd,
-        grid_subset_index::Int,
-    )
+    get_grid_subset(grid_ggd::all__grid_ggd, grid_subset_index::Int)
 
 Returns the grid_subset in a grid_ggd with the matching grid_subset_index
 """
-function get_grid_subset(
-    grid_ggd::IMASdd.edge_profiles__grid_ggd,
-    grid_subset_index::Int,
-)
+function get_grid_subset(grid_ggd::all__grid_ggd, grid_subset_index::Int)
     for subset ∈ grid_ggd.grid_subset
         if subset.identifier.index == grid_subset_index
             return subset
         end
     end
-
-    return error("Subset ", grid_subset_index, " not found.")
+    return error("Subset ", grid_subset_name, " not found.")
 end
 
 """
-    get_grid_subset(
-        grid_ggd::IMASdd.edge_profiles__grid_ggd,
-        grid_subset_name::String,
-    )
+    get_grid_subset(grid_ggd::all__grid_ggd, grid_subset_name::String)
 
 Returns the grid_subset in a grid_ggd with the matching grid_subset_name
 """
-function get_grid_subset(
-    grid_ggd::IMASdd.edge_profiles__grid_ggd,
-    grid_subset_name::String,
-)
+function get_grid_subset(grid_ggd::all__grid_ggd, grid_subset_name::String)
     for subset ∈ grid_ggd.grid_subset
         if subset.identifier.name == grid_subset_name
             return subset
         end
     end
-
     return error("Subset ", grid_subset_name, " not found.")
 end
 
 """
     get_subset_boundary_inds(
-        space::IMASdd.edge_profiles__grid_ggd___space,
-        subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
-    )
+        space::all__space,
+        subset::all__grid_subset,
+    )::Array{Int}
 
 Returns an array of space object indices corresponding to the boundary of the subset.
 That means, it returns indices of nodes that are at the end of open edge subset or
@@ -145,9 +125,9 @@ it returns the indices of edges that are the the boundary of a cell subset.
 Returns an empty array if the subset is 1D (nodes).
 """
 function get_subset_boundary_inds(
-    space::IMASdd.edge_profiles__grid_ggd___space,
-    subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
-)
+    space::all__space,
+    subset::all__grid_subset,
+)::Array{Int}
     nD = subset.element[1].object[1].dimension
     if nD > 1  # Only 2D (edges) and 3D (cells) subsets have boundaries
         nD_objects = space.objects_per_dimension[nD].object
@@ -158,91 +138,79 @@ function get_subset_boundary_inds(
         end
         return boundary_inds
     end
-    return [] # 1D (nodes) subsets have no boundary
+    return Int[] # 1D (nodes) subsets have no boundary
 end
 
 """
     get_subset_boundary(
-        space::IMASdd.edge_profiles__grid_ggd___space,
-        subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
-    )
+        space::all__space,
+        subset::all__grid_subset,
+    )::all__grid_subset
 
 Returns an array of elements of grid_subset generated from the boundary of the subset
 provided. The dimension of these elments is reduced by 1.
 """
 function get_subset_boundary(
-    space::IMASdd.edge_profiles__grid_ggd___space,
-    subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
-)
-    ret_subset = IMASdd.edge_profiles__grid_ggd___grid_subset()
+    space::all__space,
+    subset::all__grid_subset,
+)::all__grid_subset
+    ret_subset = typeof(subset)()
     boundary_inds = get_subset_boundary_inds(space, subset)
     bnd_dim = subset.element[1].object[1].dimension - 1
     space_number = subset.element[1].object[1].space
     add_subset_element!(ret_subset, space_number, bnd_dim, boundary_inds)
-    return ret_subset.element
+    return ret_subset
 end
 
 """
     subset_do(
         set_operator,
-        itrs::Vararg{
-            AbstractVector{<:IMASdd.edge_profiles__grid_ggd___grid_subset___element},
-        };
-        space::IMASdd.edge_profiles__grid_ggd___space=IMASdd.edge_profiles__grid_ggd___space(),
-        use_nodes=false
-    )
+        itrs::Vararg{all__grid_subset};
+        space::all__space,
+        use_nodes=false,
+    )::all__grid_subset
 
 Function to perform any set operation (intersect, union, setdiff etc.) on
 subset.element to generate a list of elements to go to subset object. If use_nodes is
 true, the set operation will be applied on the set of nodes from subset.element, space
 argument is required for this.
-Note: that the arguments are subset.element (not the subset itself). Similarly, the
-return object is a list of IMASdd.edge_profiles__grid_ggd___grid_subset___element.
 """
 function subset_do(
     set_operator,
-    itrs::Vararg{
-        AbstractVector{<:IMASdd.edge_profiles__grid_ggd___grid_subset___element},
-    };
-    space::IMASdd.edge_profiles__grid_ggd___space=IMASdd.edge_profiles__grid_ggd___space(),
+    itrs::Vararg{all__grid_subset};
+    space::all__space,
     use_nodes=false,
-)
+)::all__grid_subset
     if use_nodes
         ele_inds = set_operator(
             [
                 union([
-                        obj.nodes for obj ∈ get_subset_space(space, set_elements)
-                    ]...
-                ) for set_elements ∈ itrs
+                    obj.nodes for obj ∈ get_subset_space(space, subset)
+                ]...
+                ) for subset ∈ itrs
             ]...,
         )
         dim = 1
     else
         ele_inds = set_operator(
-            [[ele.object[1].index for ele ∈ set_elements] for set_elements ∈ itrs]...,
+            [[ele.object[1].index for ele ∈ subset.element] for subset ∈ itrs]...,
         )
         dim = itrs[1][1].object[1].dimension
     end
-    ret_subset = IMASdd.edge_profiles__grid_ggd___grid_subset()
+    ret_subset = typeof(itrs[1][1])()
     space_number = itrs[1][1].object[1].space
     add_subset_element!(ret_subset, space_number, dim, ele_inds)
-    return ret_subset.element
+    return ret_subset
 end
 
 """
-    get_subset_centers(
-        space::IMASdd.edge_profiles__grid_ggd___space,
-        subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
-    )
+    get_subset_centers(space::all__space, subset::all__grid_subset)
 
 Returns an array of tuples corresponding to (r,z) coordinates of the center of
 cells or the center of edges in the subset space.
 """
-function get_subset_centers(
-    space::IMASdd.edge_profiles__grid_ggd___space,
-    subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
-)
-    subset_space = get_subset_space(space, subset.element)
+function get_subset_centers(space::all__space, subset::all__grid_subset)
+    subset_space = get_subset_space(space, subset)
     if subset.element[1].object[1].dimension == 1
         return [Tuple(obj.geometry) for obj ∈ subset_space]
     end
@@ -255,16 +223,16 @@ end
 
 """
     project_prop_on_subset!(
-        prop_arr::AbstractVector{T},
-        from_subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
-        to_subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
-        space::IMASdd.edge_profiles__grid_ggd___space,
+        prop_arr::AbstractVector{<:all__grid_subset_prop},
+        from_subset::all__grid_subset,
+        to_subset::all__grid_subset,
+        space::all__space,
         value_field::Symbol=:values;
         TPS_mats::Union{
             Nothing,
             Tuple{Matrix{U}, Matrix{U}, Matrix{U}, Vector{Tuple{U, U}}},
         }=nothing,
-    ) where {T <: edge_profiles__prop_on_subset, U <: Real}
+    ) where {U <: Real}
 
 This function can be used to add another instance on a property vector representing the
 value in a new subset that can be taken as a projection from an existing larger subset.
@@ -304,16 +272,16 @@ to_prop_values: The projected values of the properties added to prop object in a
 instance
 """
 function project_prop_on_subset!(
-    prop_arr::AbstractVector{T},
-    from_subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
-    to_subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
-    space::IMASdd.edge_profiles__grid_ggd___space,
+    prop_arr::AbstractVector{<:all__grid_subset_prop},
+    from_subset::all__grid_subset,
+    to_subset::all__grid_subset,
+    space::all__space,
     value_field::Symbol=:values;
     TPS_mats::Union{
         Nothing,
         Tuple{Matrix{U}, Matrix{U}, Matrix{U}, Vector{Tuple{U, U}}},
     }=nothing,
-) where {T <: edge_profiles__prop_on_subset, U <: Real}
+) where {U <: Real}
     if from_subset.element[1].object[1].dimension ==
        to_subset.element[1].object[1].dimension
         return project_prop_on_subset!(prop, from_subset, to_subset)
@@ -359,11 +327,11 @@ end
 
 """
     project_prop_on_subset!(
-        prop_arr::AbstractVector{T},
-        from_subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
-        to_subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
+        prop_arr::AbstractVector{<:all__grid_subset_prop},
+        from_subset::all__grid_subset,
+        to_subset::all__grid_subset,
         value_field::Symbol=:values,
-    ) where {T <: edge_profiles__prop_on_subset}
+    )
 
 If the dimensions of from_subset and to_subset are the same, this function can be used
 to add another instance on a property vector representing the value in to_subset without
@@ -371,11 +339,11 @@ any interpolation or use of space object. The function returns a tuple of indice
 elements of to_subset and the values of the property in to_subset.
 """
 function project_prop_on_subset!(
-    prop_arr::AbstractVector{T},
-    from_subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
-    to_subset::IMASdd.edge_profiles__grid_ggd___grid_subset,
+    prop_arr::AbstractVector{<:all__grid_subset_prop},
+    from_subset::all__grid_subset,
+    to_subset::all__grid_subset,
     value_field::Symbol=:values,
-) where {T <: edge_profiles__prop_on_subset}
+)
     from_prop = get_prop_with_grid_subset_index(prop_arr, from_subset.identifier.index)
     if length(prop_arr) < 1
         error(
@@ -430,13 +398,13 @@ function project_prop_on_subset!(
 end
 
 """
-    deepcopy_subset(subset::IMASdd.edge_profiles__grid_ggd___grid_subset)
+    deepcopy_subset(subset::all__grid_subset)::all__grid_subset
 
 Faster deepcopy function for grid_subset object. This function is used to create a deep
 copy of a grid_subset object bypassing several checks performed by IMASdd.
 """
-function deepcopy_subset(subset::IMASdd.edge_profiles__grid_ggd___grid_subset)
-    new_subset = IMASdd.edge_profiles__grid_ggd___grid_subset()
+function deepcopy_subset(subset::all__grid_subset)::all__grid_subset
+    new_subset = all__grid_subset()
 
     base = getfield(subset, :base)
     new_base = getfield(new_subset, :base)
@@ -508,11 +476,8 @@ end
 """
     Base.:∈(
         point::Tuple{Real, Real},
-        subset_of_space::Tuple{
-            IMASdd.edge_profiles__grid_ggd___grid_subset,
-            IMASdd.edge_profiles__grid_ggd___space,
-        },
-    )
+        subset_of_space::Tuple{all__grid_subset, all__space},
+    )::Bool
 
 Overloading ∈ operator to check if a point is inside a subset of space.
 
@@ -534,11 +499,8 @@ end
 """
 function Base.:∈(
     point::Tuple{Real, Real},
-    subset_of_space::Tuple{
-        IMASdd.edge_profiles__grid_ggd___grid_subset,
-        IMASdd.edge_profiles__grid_ggd___space,
-    },
-)
+    subset_of_space::Tuple{all__grid_subset, all__space},
+)::Bool
     r, z = point
     subset, space = subset_of_space
     dim = getfield(getfield(getfield(subset, :element)[1], :object)[1], :dimension)
@@ -546,8 +508,7 @@ function Base.:∈(
     nodes = getfield(opd[1], :object)
     edges = getfield(opd[2], :object)
     if dim == 3
-        subset_bnd = IMASdd.edge_profiles__grid_ggd___grid_subset()
-        subset_bnd.element = get_subset_boundary(space, subset)
+        subset_bnd = get_subset_boundary(space, subset)
     elseif dim == 2
         subset_bnd = subset
     elseif dim == 1
@@ -586,17 +547,17 @@ end
 
 """
     get_prop_with_grid_subset_index(
-        prop::AbstractVector{T},
+        prop::AbstractVector{<:all__grid_subset_prop},
         grid_subset_index::Int,
-    ) where {T <: edge_profiles__prop_on_subset}
+    )
 
-Find the edge_profiles property instance in an array of properties that corresponds to
+Find the property instance in an array of properties that corresponds to
 the grid_subset_index provided.
 """
 function get_prop_with_grid_subset_index(
-    prop::AbstractVector{T},
+    prop::AbstractVector{<:all__grid_subset_prop},
     grid_subset_index::Int,
-) where {T <: edge_profiles__prop_on_subset}
+)
     for p ∈ prop
         if p.grid_subset_index == grid_subset_index
             return p

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,7 +1,11 @@
 export get_types_with
 
 """
-    get_types_with(parent::Type, field::Symbol)
+    get_types_with(
+        parent::Type,
+        field::Symbol;
+        return_field_type::Bool=false,
+    )::Array{Type}
 
 A type creation utility meant for searching types in IMAS database. This function
 returns a list of types that are fields at any level below the parent data type which
@@ -17,108 +21,636 @@ returns all edge_profiles types that have a subfield named grid_subset_index. No
 this function can give errors sometimes and for sake of speed and stability it is
 recommended to always create union of types with hardcodes type names.
 """
-function get_types_with(parent::Type, field::Symbol)
+function get_types_with(
+    parent::Type,
+    field::Symbol;
+    return_field_type::Bool=false,
+)::Array{Type}
     if field ∈ fieldnames(parent)
-        return [parent]
-    end
-    ret = Type[]
-    for f ∈ fieldnames(parent)
-        T = typeof(getfield(parent(), f))
-        if T <: AbstractArray || T <: Tuple
-            eT = eltype(T)
-            if field ∈ fieldnames(eT)
-                append!(ret, [eT])
-            else
-                append!(ret, get_types_with(eT, field))
-            end
-        else
-            if field ∈ fieldnames(T)
-                append!(ret, [T])
-            else
-                append!(ret, get_types_with(T, field))
+        ret = [parent]
+    else
+        ret = Type[]
+        for f ∈ fieldnames(parent)
+            if !startswith(string(f), "_")
+                T = fieldtype(parent, f)
+                if !(T <: AbstractArray{<:Number} || T <: Number)
+                    if T <: AbstractArray || T <: Tuple
+                        eT = eltype(T)
+                        if eT <: Number
+                            continue
+                        end
+                        if field ∈ fieldnames(eT)
+                            append!(ret, [eT])
+                        else
+                            append!(ret, get_types_with(eT, field))
+                        end
+                    else
+                        if field ∈ fieldnames(T)
+                            append!(ret, [T])
+                        else
+                            append!(ret, get_types_with(T, field))
+                        end
+                    end
+                end
             end
         end
     end
-    return ret
+    if return_field_type
+        fret = Type[]
+        for T ∈ ret
+            fT = fieldtype(T, field)
+            if fT <: AbstractArray || fT <: Tuple
+                append!(fret, [eltype(fT)])
+            else
+                append!(fret, [fT])
+            end
+        end
+        return fret
+    else
+        return ret
+    end
 end
 
-edge_profiles__prop_on_subset =
+"""
+    all__grid_ggd =
+        Union{
+            IMASdd.edge_profiles__grid_ggd{T},
+            IMASdd.edge_sources__grid_ggd{T},
+            IMASdd.edge_transport__grid_ggd{T},
+            IMASdd.em_coupling__grid_ggd{T},
+            IMASdd.ferritic__grid_ggd{T},
+            IMASdd.mhd__grid_ggd{T},
+            IMASdd.radiation__grid_ggd{T},
+            IMASdd.runaway_electrons__grid_ggd{T},
+            IMASdd.wall__description_ggd___grid_ggd{T},
+        } where {T};
+
+Union of all IMAS data dictionary `grid_ggd` types.
+"""
+all__grid_ggd =
     Union{
-        IMASdd.edge_profiles__ggd___a_field_parallel{Float64},
-        IMASdd.edge_profiles__ggd___e_field{Float64},
-        IMASdd.edge_profiles__ggd___electrons__density{Float64},
-        IMASdd.edge_profiles__ggd___electrons__density_fast{Float64},
-        IMASdd.edge_profiles__ggd___electrons__distribution_function{Float64},
-        IMASdd.edge_profiles__ggd___electrons__pressure{Float64},
-        IMASdd.edge_profiles__ggd___electrons__pressure_fast_parallel{Float64},
-        IMASdd.edge_profiles__ggd___electrons__pressure_fast_perpendicular{Float64},
-        IMASdd.edge_profiles__ggd___electrons__temperature{Float64},
-        IMASdd.edge_profiles__ggd___electrons__velocity{Float64},
-        IMASdd.edge_profiles__ggd___ion___density{Float64},
-        IMASdd.edge_profiles__ggd___ion___density_fast{Float64},
-        IMASdd.edge_profiles__ggd___ion___energy_density_kinetic{Float64},
-        IMASdd.edge_profiles__ggd___ion___pressure{Float64},
-        IMASdd.edge_profiles__ggd___ion___pressure_fast_parallel{Float64},
-        IMASdd.edge_profiles__ggd___ion___pressure_fast_perpendicular{Float64},
-        IMASdd.edge_profiles__ggd___ion___state___density{Float64},
-        IMASdd.edge_profiles__ggd___ion___state___density_fast{Float64},
-        IMASdd.edge_profiles__ggd___ion___state___distribution_function{Float64},
-        IMASdd.edge_profiles__ggd___ion___state___energy_density_kinetic{Float64},
-        IMASdd.edge_profiles__ggd___ion___state___ionisation_potential{Float64},
-        IMASdd.edge_profiles__ggd___ion___state___pressure{Float64},
-        IMASdd.edge_profiles__ggd___ion___state___pressure_fast_parallel{Float64},
-        IMASdd.edge_profiles__ggd___ion___state___pressure_fast_perpendicular{Float64},
-        IMASdd.edge_profiles__ggd___ion___state___temperature{Float64},
-        IMASdd.edge_profiles__ggd___ion___state___velocity{Float64},
-        IMASdd.edge_profiles__ggd___ion___state___velocity_diamagnetic{Float64},
-        IMASdd.edge_profiles__ggd___ion___state___velocity_exb{Float64},
-        IMASdd.edge_profiles__ggd___ion___state___z_average{Float64},
-        IMASdd.edge_profiles__ggd___ion___state___z_square_average{Float64},
-        IMASdd.edge_profiles__ggd___ion___temperature{Float64},
-        IMASdd.edge_profiles__ggd___ion___velocity{Float64},
-        IMASdd.edge_profiles__ggd___j_anomalous{Float64},
-        IMASdd.edge_profiles__ggd___j_diamagnetic{Float64},
-        IMASdd.edge_profiles__ggd___j_heat_viscosity{Float64},
-        IMASdd.edge_profiles__ggd___j_inertial{Float64},
-        IMASdd.edge_profiles__ggd___j_ion_neutral_friction{Float64},
-        IMASdd.edge_profiles__ggd___j_parallel{Float64},
-        IMASdd.edge_profiles__ggd___j_parallel_viscosity{Float64},
-        IMASdd.edge_profiles__ggd___j_perpendicular_viscosity{Float64},
-        IMASdd.edge_profiles__ggd___j_pfirsch_schlueter{Float64},
-        IMASdd.edge_profiles__ggd___j_total{Float64},
-        IMASdd.edge_profiles__ggd___n_i_total_over_n_e{Float64},
-        IMASdd.edge_profiles__ggd___neutral___density{Float64},
-        IMASdd.edge_profiles__ggd___neutral___density_fast{Float64},
-        IMASdd.edge_profiles__ggd___neutral___energy_density_kinetic{Float64},
-        IMASdd.edge_profiles__ggd___neutral___pressure{Float64},
-        IMASdd.edge_profiles__ggd___neutral___pressure_fast_parallel{Float64},
-        IMASdd.edge_profiles__ggd___neutral___pressure_fast_perpendicular{Float64},
-        IMASdd.edge_profiles__ggd___neutral___state___density{Float64},
-        IMASdd.edge_profiles__ggd___neutral___state___density_fast{Float64},
-        IMASdd.edge_profiles__ggd___neutral___state___distribution_function{Float64},
-        IMASdd.edge_profiles__ggd___neutral___state___energy_density_kinetic{Float64},
-        IMASdd.edge_profiles__ggd___neutral___state___pressure{Float64},
-        IMASdd.edge_profiles__ggd___neutral___state___pressure_fast_parallel{Float64},
-        IMASdd.edge_profiles__ggd___neutral___state___pressure_fast_perpendicular{
-            Float64,
+        IMASdd.edge_profiles__grid_ggd{T},
+        IMASdd.edge_sources__grid_ggd{T},
+        IMASdd.edge_transport__grid_ggd{T},
+        IMASdd.em_coupling__grid_ggd{T},
+        IMASdd.ferritic__grid_ggd{T},
+        IMASdd.mhd__grid_ggd{T},
+        IMASdd.radiation__grid_ggd{T},
+        IMASdd.runaway_electrons__grid_ggd{T},
+        IMASdd.wall__description_ggd___grid_ggd{T},
+    } where {T};
+
+"""
+    all__space =
+        Union{
+            IMASdd.distribution_sources__source___ggd___grid__space{T},
+            IMASdd.distributions__distribution___ggd___grid__space{T},
+            IMASdd.edge_profiles__grid_ggd___space{T},
+            IMASdd.edge_sources__grid_ggd___space{T},
+            IMASdd.edge_transport__grid_ggd___space{T},
+            IMASdd.em_coupling__grid_ggd___space{T},
+            IMASdd.equilibrium__grids_ggd___grid___space{T},
+            IMASdd.ferritic__grid_ggd__space{T},
+            IMASdd.mhd__grid_ggd___space{T},
+            IMASdd.radiation__grid_ggd___space{T},
+            IMASdd.runaway_electrons__grid_ggd___space{T},
+            IMASdd.tf__field_map___grid__space{T},
+            IMASdd.transport_solver_numerics__boundary_conditions_ggd___grid__space{T},
+            IMASdd.wall__description_ggd___grid_ggd___space{T},
+            IMASdd.waves__coherent_wave___full_wave___grid__space{T},
+        } where {T};
+
+Union of all `space` types that are attributes of `grid_ggd` objects in IMAS.
+"""
+all__space =
+    Union{
+        IMASdd.distribution_sources__source___ggd___grid__space{T},
+        IMASdd.distributions__distribution___ggd___grid__space{T},
+        IMASdd.edge_profiles__grid_ggd___space{T},
+        IMASdd.edge_sources__grid_ggd___space{T},
+        IMASdd.edge_transport__grid_ggd___space{T},
+        IMASdd.em_coupling__grid_ggd___space{T},
+        IMASdd.equilibrium__grids_ggd___grid___space{T},
+        IMASdd.ferritic__grid_ggd__space{T},
+        IMASdd.mhd__grid_ggd___space{T},
+        IMASdd.radiation__grid_ggd___space{T},
+        IMASdd.runaway_electrons__grid_ggd___space{T},
+        IMASdd.tf__field_map___grid__space{T},
+        IMASdd.transport_solver_numerics__boundary_conditions_ggd___grid__space{T},
+        IMASdd.wall__description_ggd___grid_ggd___space{T},
+        IMASdd.waves__coherent_wave___full_wave___grid__space{T},
+    } where {T};
+
+"""
+    all__grid_subset =
+        Union{
+            IMASdd.edge_profiles__grid_ggd___grid_subset{T},
+            IMASdd.edge_sources__grid_ggd___grid_subset{T},
+            IMASdd.edge_transport__grid_ggd___grid_subset{T},
+            IMASdd.em_coupling__grid_ggd___grid_subset{T},
+            IMASdd.ferritic__grid_ggd__grid_subset{T},
+            IMASdd.mhd__grid_ggd___grid_subset{T},
+            IMASdd.radiation__grid_ggd___grid_subset{T},
+            IMASdd.runaway_electrons__grid_ggd___grid_subset{T},
+            IMASdd.wall__description_ggd___grid_ggd___grid_subset{T},
+        } where {T};
+
+Union of all `grid_subset` types are attributes of `grid_ggd` objects in IMAS.
+"""
+all__grid_subset =
+    Union{
+        IMASdd.edge_profiles__grid_ggd___grid_subset{T},
+        IMASdd.edge_sources__grid_ggd___grid_subset{T},
+        IMASdd.edge_transport__grid_ggd___grid_subset{T},
+        IMASdd.em_coupling__grid_ggd___grid_subset{T},
+        IMASdd.ferritic__grid_ggd__grid_subset{T},
+        IMASdd.mhd__grid_ggd___grid_subset{T},
+        IMASdd.radiation__grid_ggd___grid_subset{T},
+        IMASdd.runaway_electrons__grid_ggd___grid_subset{T},
+        IMASdd.wall__description_ggd___grid_ggd___grid_subset{T},
+    } where {T};
+
+"""
+    all__grid_subset_prop
+
+A large union of all `ggd` properties that refer to a `grid_subset` for the dimensions
+of the data.
+"""
+all__grid_subset_prop =
+    Union{
+        IMASdd.core_profiles__statistics___quantity_2d___statistics_type{T},
+        IMASdd.distribution_sources__source___ggd___particles{T},
+        IMASdd.distributions__distribution___ggd___expansion___grid_subset{T},
+        IMASdd.distributions__distribution___ggd___expansion_fd3v___grid_subset{T},
+        IMASdd.edge_profiles__ggd___a_field_parallel{T},
+        IMASdd.edge_profiles__ggd___e_field{T},
+        IMASdd.edge_profiles__ggd___electrons__density{T},
+        IMASdd.edge_profiles__ggd___electrons__density_fast{T},
+        IMASdd.edge_profiles__ggd___electrons__distribution_function{T},
+        IMASdd.edge_profiles__ggd___electrons__pressure{T},
+        IMASdd.edge_profiles__ggd___electrons__pressure_fast_parallel{T},
+        IMASdd.edge_profiles__ggd___electrons__pressure_fast_perpendicular{T},
+        IMASdd.edge_profiles__ggd___electrons__temperature{T},
+        IMASdd.edge_profiles__ggd___electrons__velocity{T},
+        IMASdd.edge_profiles__ggd___ion___density{T},
+        IMASdd.edge_profiles__ggd___ion___density_fast{T},
+        IMASdd.edge_profiles__ggd___ion___energy_density_kinetic{T},
+        IMASdd.edge_profiles__ggd___ion___pressure{T},
+        IMASdd.edge_profiles__ggd___ion___pressure_fast_parallel{T},
+        IMASdd.edge_profiles__ggd___ion___pressure_fast_perpendicular{T},
+        IMASdd.edge_profiles__ggd___ion___state___density{T},
+        IMASdd.edge_profiles__ggd___ion___state___density_fast{T},
+        IMASdd.edge_profiles__ggd___ion___state___distribution_function{T},
+        IMASdd.edge_profiles__ggd___ion___state___energy_density_kinetic{T},
+        IMASdd.edge_profiles__ggd___ion___state___ionisation_potential{T},
+        IMASdd.edge_profiles__ggd___ion___state___pressure{T},
+        IMASdd.edge_profiles__ggd___ion___state___pressure_fast_parallel{T},
+        IMASdd.edge_profiles__ggd___ion___state___pressure_fast_perpendicular{T},
+        IMASdd.edge_profiles__ggd___ion___state___temperature{T},
+        IMASdd.edge_profiles__ggd___ion___state___velocity{T},
+        IMASdd.edge_profiles__ggd___ion___state___velocity_diamagnetic{T},
+        IMASdd.edge_profiles__ggd___ion___state___velocity_exb{T},
+        IMASdd.edge_profiles__ggd___ion___state___z_average{T},
+        IMASdd.edge_profiles__ggd___ion___state___z_square_average{T},
+        IMASdd.edge_profiles__ggd___ion___temperature{T},
+        IMASdd.edge_profiles__ggd___ion___velocity{T},
+        IMASdd.edge_profiles__ggd___j_anomalous{T},
+        IMASdd.edge_profiles__ggd___j_diamagnetic{T},
+        IMASdd.edge_profiles__ggd___j_heat_viscosity{T},
+        IMASdd.edge_profiles__ggd___j_inertial{T},
+        IMASdd.edge_profiles__ggd___j_ion_neutral_friction{T},
+        IMASdd.edge_profiles__ggd___j_parallel{T},
+        IMASdd.edge_profiles__ggd___j_parallel_viscosity{T},
+        IMASdd.edge_profiles__ggd___j_perpendicular_viscosity{T},
+        IMASdd.edge_profiles__ggd___j_pfirsch_schlueter{T},
+        IMASdd.edge_profiles__ggd___j_total{T},
+        IMASdd.edge_profiles__ggd___n_i_total_over_n_e{T},
+        IMASdd.edge_profiles__ggd___neutral___density{T},
+        IMASdd.edge_profiles__ggd___neutral___density_fast{T},
+        IMASdd.edge_profiles__ggd___neutral___energy_density_kinetic{T},
+        IMASdd.edge_profiles__ggd___neutral___pressure{T},
+        IMASdd.edge_profiles__ggd___neutral___pressure_fast_parallel{T},
+        IMASdd.edge_profiles__ggd___neutral___pressure_fast_perpendicular{T},
+        IMASdd.edge_profiles__ggd___neutral___state___density{T},
+        IMASdd.edge_profiles__ggd___neutral___state___density_fast{T},
+        IMASdd.edge_profiles__ggd___neutral___state___distribution_function{T},
+        IMASdd.edge_profiles__ggd___neutral___state___energy_density_kinetic{T},
+        IMASdd.edge_profiles__ggd___neutral___state___pressure{T},
+        IMASdd.edge_profiles__ggd___neutral___state___pressure_fast_parallel{T},
+        IMASdd.edge_profiles__ggd___neutral___state___pressure_fast_perpendicular{T},
+        IMASdd.edge_profiles__ggd___neutral___state___temperature{T},
+        IMASdd.edge_profiles__ggd___neutral___state___velocity{T},
+        IMASdd.edge_profiles__ggd___neutral___state___velocity_diamagnetic{T},
+        IMASdd.edge_profiles__ggd___neutral___state___velocity_exb{T},
+        IMASdd.edge_profiles__ggd___neutral___temperature{T},
+        IMASdd.edge_profiles__ggd___neutral___velocity{T},
+        IMASdd.edge_profiles__ggd___phi_potential{T},
+        IMASdd.edge_profiles__ggd___pressure_parallel{T},
+        IMASdd.edge_profiles__ggd___pressure_perpendicular{T},
+        IMASdd.edge_profiles__ggd___pressure_thermal{T},
+        IMASdd.edge_profiles__ggd___t_i_average{T},
+        IMASdd.edge_profiles__ggd___zeff{T},
+        IMASdd.edge_profiles__ggd_fast___electrons__density{T},
+        IMASdd.edge_profiles__ggd_fast___electrons__temperature{T},
+        IMASdd.edge_profiles__ggd_fast___energy_thermal{T},
+        IMASdd.edge_profiles__ggd_fast___ion___content{T},
+        IMASdd.edge_profiles__ggd_fast___ion___density{T},
+        IMASdd.edge_profiles__ggd_fast___ion___temperature{T},
+        IMASdd.edge_profiles__statistics___quantity_2d___statistics_type{T},
+        IMASdd.edge_sources__source___ggd___current{T},
+        IMASdd.edge_sources__source___ggd___electrons__energy{T},
+        IMASdd.edge_sources__source___ggd___electrons__particles{T},
+        IMASdd.edge_sources__source___ggd___ion___energy{T},
+        IMASdd.edge_sources__source___ggd___ion___momentum{T},
+        IMASdd.edge_sources__source___ggd___ion___particles{T},
+        IMASdd.edge_sources__source___ggd___ion___state___energy{T},
+        IMASdd.edge_sources__source___ggd___ion___state___momentum{T},
+        IMASdd.edge_sources__source___ggd___ion___state___particles{T},
+        IMASdd.edge_sources__source___ggd___momentum{T},
+        IMASdd.edge_sources__source___ggd___neutral___energy{T},
+        IMASdd.edge_sources__source___ggd___neutral___momentum{T},
+        IMASdd.edge_sources__source___ggd___neutral___particles{T},
+        IMASdd.edge_sources__source___ggd___neutral___state___energy{T},
+        IMASdd.edge_sources__source___ggd___neutral___state___momentum{T},
+        IMASdd.edge_sources__source___ggd___neutral___state___particles{T},
+        IMASdd.edge_sources__source___ggd___total_ion_energy{T},
+        IMASdd.edge_sources__source___ggd_fast___ion___power{T},
+        IMASdd.edge_transport__model___ggd___conductivity{T},
+        IMASdd.edge_transport__model___ggd___electrons__energy__d{T},
+        IMASdd.edge_transport__model___ggd___electrons__energy__d_pol{T},
+        IMASdd.edge_transport__model___ggd___electrons__energy__d_radial{T},
+        IMASdd.edge_transport__model___ggd___electrons__energy__flux{T},
+        IMASdd.edge_transport__model___ggd___electrons__energy__flux_limiter{T},
+        IMASdd.edge_transport__model___ggd___electrons__energy__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___electrons__energy__flux_radial{T},
+        IMASdd.edge_transport__model___ggd___electrons__energy__v{T},
+        IMASdd.edge_transport__model___ggd___electrons__energy__v_pol{T},
+        IMASdd.edge_transport__model___ggd___electrons__energy__v_radial{T},
+        IMASdd.edge_transport__model___ggd___electrons__particles__d{T},
+        IMASdd.edge_transport__model___ggd___electrons__particles__d_pol{T},
+        IMASdd.edge_transport__model___ggd___electrons__particles__d_radial{T},
+        IMASdd.edge_transport__model___ggd___electrons__particles__flux{T},
+        IMASdd.edge_transport__model___ggd___electrons__particles__flux_limiter{T},
+        IMASdd.edge_transport__model___ggd___electrons__particles__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___electrons__particles__flux_radial{T},
+        IMASdd.edge_transport__model___ggd___electrons__particles__v{T},
+        IMASdd.edge_transport__model___ggd___electrons__particles__v_pol{T},
+        IMASdd.edge_transport__model___ggd___electrons__particles__v_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___energy__d{T},
+        IMASdd.edge_transport__model___ggd___ion___energy__d_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___energy__d_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___energy__flux{T},
+        IMASdd.edge_transport__model___ggd___ion___energy__flux_limiter{T},
+        IMASdd.edge_transport__model___ggd___ion___energy__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___energy__flux_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___energy__v{T},
+        IMASdd.edge_transport__model___ggd___ion___energy__v_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___energy__v_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___momentum__d{T},
+        IMASdd.edge_transport__model___ggd___ion___momentum__d_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___momentum__d_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___momentum__flux{T},
+        IMASdd.edge_transport__model___ggd___ion___momentum__flux_limiter{T},
+        IMASdd.edge_transport__model___ggd___ion___momentum__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___momentum__flux_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___momentum__v{T},
+        IMASdd.edge_transport__model___ggd___ion___momentum__v_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___momentum__v_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___particles__d{T},
+        IMASdd.edge_transport__model___ggd___ion___particles__d_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___particles__d_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___particles__flux{T},
+        IMASdd.edge_transport__model___ggd___ion___particles__flux_limiter{T},
+        IMASdd.edge_transport__model___ggd___ion___particles__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___particles__flux_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___particles__v{T},
+        IMASdd.edge_transport__model___ggd___ion___particles__v_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___particles__v_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___state___energy__d{T},
+        IMASdd.edge_transport__model___ggd___ion___state___energy__d_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___state___energy__d_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___state___energy__flux{T},
+        IMASdd.edge_transport__model___ggd___ion___state___energy__flux_limiter{T},
+        IMASdd.edge_transport__model___ggd___ion___state___energy__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___state___energy__flux_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___state___energy__v{T},
+        IMASdd.edge_transport__model___ggd___ion___state___energy__v_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___state___energy__v_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___state___momentum__d{T},
+        IMASdd.edge_transport__model___ggd___ion___state___momentum__d_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___state___momentum__d_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___state___momentum__flux{T},
+        IMASdd.edge_transport__model___ggd___ion___state___momentum__flux_limiter{T},
+        IMASdd.edge_transport__model___ggd___ion___state___momentum__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___state___momentum__flux_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___state___momentum__v{T},
+        IMASdd.edge_transport__model___ggd___ion___state___momentum__v_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___state___momentum__v_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___state___particles__d{T},
+        IMASdd.edge_transport__model___ggd___ion___state___particles__d_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___state___particles__d_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___state___particles__flux{T},
+        IMASdd.edge_transport__model___ggd___ion___state___particles__flux_limiter{T},
+        IMASdd.edge_transport__model___ggd___ion___state___particles__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___state___particles__flux_radial{T},
+        IMASdd.edge_transport__model___ggd___ion___state___particles__v{T},
+        IMASdd.edge_transport__model___ggd___ion___state___particles__v_pol{T},
+        IMASdd.edge_transport__model___ggd___ion___state___particles__v_radial{T},
+        IMASdd.edge_transport__model___ggd___momentum__d{T},
+        IMASdd.edge_transport__model___ggd___momentum__d_pol{T},
+        IMASdd.edge_transport__model___ggd___momentum__d_radial{T},
+        IMASdd.edge_transport__model___ggd___momentum__flux{T},
+        IMASdd.edge_transport__model___ggd___momentum__flux_limiter{T},
+        IMASdd.edge_transport__model___ggd___momentum__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___momentum__flux_radial{T},
+        IMASdd.edge_transport__model___ggd___momentum__v{T},
+        IMASdd.edge_transport__model___ggd___momentum__v_pol{T},
+        IMASdd.edge_transport__model___ggd___momentum__v_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___energy__d{T},
+        IMASdd.edge_transport__model___ggd___neutral___energy__d_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___energy__d_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___energy__flux{T},
+        IMASdd.edge_transport__model___ggd___neutral___energy__flux_limiter{T},
+        IMASdd.edge_transport__model___ggd___neutral___energy__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___energy__flux_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___energy__v{T},
+        IMASdd.edge_transport__model___ggd___neutral___energy__v_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___energy__v_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___momentum__d{T},
+        IMASdd.edge_transport__model___ggd___neutral___momentum__d_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___momentum__d_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___momentum__flux{T},
+        IMASdd.edge_transport__model___ggd___neutral___momentum__flux_limiter{T},
+        IMASdd.edge_transport__model___ggd___neutral___momentum__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___momentum__flux_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___momentum__v{T},
+        IMASdd.edge_transport__model___ggd___neutral___momentum__v_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___momentum__v_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___particles__d{T},
+        IMASdd.edge_transport__model___ggd___neutral___particles__d_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___particles__d_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___particles__flux{T},
+        IMASdd.edge_transport__model___ggd___neutral___particles__flux_limiter{T},
+        IMASdd.edge_transport__model___ggd___neutral___particles__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___particles__flux_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___particles__v{T},
+        IMASdd.edge_transport__model___ggd___neutral___particles__v_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___particles__v_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___energy__d{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___energy__d_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___energy__d_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___energy__flux{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___energy__flux_limiter{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___energy__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___energy__flux_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___energy__v{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___energy__v_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___energy__v_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___momentum__d{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___momentum__d_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___momentum__d_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___momentum__flux{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___momentum__flux_limiter{
+            T,
         },
-        IMASdd.edge_profiles__ggd___neutral___state___temperature{Float64},
-        IMASdd.edge_profiles__ggd___neutral___state___velocity{Float64},
-        IMASdd.edge_profiles__ggd___neutral___state___velocity_diamagnetic{Float64},
-        IMASdd.edge_profiles__ggd___neutral___state___velocity_exb{Float64},
-        IMASdd.edge_profiles__ggd___neutral___temperature{Float64},
-        IMASdd.edge_profiles__ggd___neutral___velocity{Float64},
-        IMASdd.edge_profiles__ggd___phi_potential{Float64},
-        IMASdd.edge_profiles__ggd___pressure_parallel{Float64},
-        IMASdd.edge_profiles__ggd___pressure_perpendicular{Float64},
-        IMASdd.edge_profiles__ggd___pressure_thermal{Float64},
-        IMASdd.edge_profiles__ggd___t_i_average{Float64},
-        IMASdd.edge_profiles__ggd___zeff{Float64},
-        IMASdd.edge_profiles__ggd_fast___electrons__density{Float64},
-        IMASdd.edge_profiles__ggd_fast___electrons__temperature{Float64},
-        IMASdd.edge_profiles__ggd_fast___energy_thermal{Float64},
-        IMASdd.edge_profiles__ggd_fast___ion___content{Float64},
-        IMASdd.edge_profiles__ggd_fast___ion___density{Float64},
-        IMASdd.edge_profiles__ggd_fast___ion___temperature{Float64},
-        IMASdd.edge_profiles__statistics___quantity_2d___statistics_type{Float64},
-    }
+        IMASdd.edge_transport__model___ggd___neutral___state___momentum__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___momentum__flux_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___momentum__v{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___momentum__v_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___momentum__v_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___particles__d{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___particles__d_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___particles__d_radial{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___particles__flux{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___particles__flux_limiter{
+            T,
+        },
+        IMASdd.edge_transport__model___ggd___neutral___state___particles__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___particles__flux_radial{
+            T,
+        },
+        IMASdd.edge_transport__model___ggd___neutral___state___particles__v{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___particles__v_pol{T},
+        IMASdd.edge_transport__model___ggd___neutral___state___particles__v_radial{T},
+        IMASdd.edge_transport__model___ggd___total_ion_energy__d{T},
+        IMASdd.edge_transport__model___ggd___total_ion_energy__d_pol{T},
+        IMASdd.edge_transport__model___ggd___total_ion_energy__d_radial{T},
+        IMASdd.edge_transport__model___ggd___total_ion_energy__flux{T},
+        IMASdd.edge_transport__model___ggd___total_ion_energy__flux_limiter{T},
+        IMASdd.edge_transport__model___ggd___total_ion_energy__flux_pol{T},
+        IMASdd.edge_transport__model___ggd___total_ion_energy__flux_radial{T},
+        IMASdd.edge_transport__model___ggd___total_ion_energy__v{T},
+        IMASdd.edge_transport__model___ggd___total_ion_energy__v_pol{T},
+        IMASdd.edge_transport__model___ggd___total_ion_energy__v_radial{T},
+        IMASdd.edge_transport__model___ggd_fast___electrons__particle_flux_integrated{
+            T,
+        },
+        IMASdd.edge_transport__model___ggd_fast___electrons__power{T},
+        IMASdd.edge_transport__model___ggd_fast___energy_flux_max{T},
+        IMASdd.edge_transport__model___ggd_fast___ion___particle_flux_integrated{T},
+        IMASdd.edge_transport__model___ggd_fast___neutral___particle_flux_integrated{T},
+        IMASdd.edge_transport__model___ggd_fast___power{T},
+        IMASdd.edge_transport__model___ggd_fast___power_ion_total{T},
+        IMASdd.equilibrium__time_slice___ggd___b_field_r{T},
+        IMASdd.equilibrium__time_slice___ggd___b_field_tor{T},
+        IMASdd.equilibrium__time_slice___ggd___b_field_z{T},
+        IMASdd.equilibrium__time_slice___ggd___j_parallel{T},
+        IMASdd.equilibrium__time_slice___ggd___j_tor{T},
+        IMASdd.equilibrium__time_slice___ggd___phi{T},
+        IMASdd.equilibrium__time_slice___ggd___psi{T},
+        IMASdd.equilibrium__time_slice___ggd___r{T},
+        IMASdd.equilibrium__time_slice___ggd___theta{T},
+        IMASdd.equilibrium__time_slice___ggd___z{T},
+        IMASdd.mhd__ggd___a_field_r{T},
+        IMASdd.mhd__ggd___a_field_tor{T},
+        IMASdd.mhd__ggd___a_field_z{T},
+        IMASdd.mhd__ggd___b_field_r{T},
+        IMASdd.mhd__ggd___b_field_tor{T},
+        IMASdd.mhd__ggd___b_field_z{T},
+        IMASdd.mhd__ggd___electrons__temperature{T},
+        IMASdd.mhd__ggd___j_r{T},
+        IMASdd.mhd__ggd___j_tor{T},
+        IMASdd.mhd__ggd___j_tor_r{T},
+        IMASdd.mhd__ggd___j_z{T},
+        IMASdd.mhd__ggd___mass_density{T},
+        IMASdd.mhd__ggd___n_i_total{T},
+        IMASdd.mhd__ggd___phi_potential{T},
+        IMASdd.mhd__ggd___psi{T},
+        IMASdd.mhd__ggd___t_i_average{T},
+        IMASdd.mhd__ggd___velocity_parallel{T},
+        IMASdd.mhd__ggd___velocity_parallel_over_b_field{T},
+        IMASdd.mhd__ggd___velocity_r{T},
+        IMASdd.mhd__ggd___velocity_tor{T},
+        IMASdd.mhd__ggd___velocity_z{T},
+        IMASdd.mhd__ggd___vorticity{T},
+        IMASdd.mhd__ggd___vorticity_over_r{T},
+        IMASdd.mhd__ggd___zeff{T},
+        IMASdd.radiation__process___ggd___electrons__emissivity{T},
+        IMASdd.radiation__process___ggd___ion___emissivity{T},
+        IMASdd.radiation__process___ggd___ion___state___emissivity{T},
+        IMASdd.radiation__process___ggd___neutral___emissivity{T},
+        IMASdd.radiation__process___ggd___neutral___state___emissivity{T},
+        IMASdd.runaway_electrons__distribution__ggd___expansion___grid_subset{T},
+        IMASdd.runaway_electrons__distribution__ggd___expansion_fd3v___grid_subset{T},
+        IMASdd.runaway_electrons__ggd_fluid___current_density{T},
+        IMASdd.runaway_electrons__ggd_fluid___ddensity_dt_compton{T},
+        IMASdd.runaway_electrons__ggd_fluid___ddensity_dt_dreicer{T},
+        IMASdd.runaway_electrons__ggd_fluid___ddensity_dt_hot_tail{T},
+        IMASdd.runaway_electrons__ggd_fluid___ddensity_dt_total{T},
+        IMASdd.runaway_electrons__ggd_fluid___ddensity_dt_tritium{T},
+        IMASdd.runaway_electrons__ggd_fluid___density{T},
+        IMASdd.runaway_electrons__ggd_fluid___e_field_critical{T},
+        IMASdd.runaway_electrons__ggd_fluid___e_field_dreicer{T},
+        IMASdd.runaway_electrons__ggd_fluid___energy_density_kinetic{T},
+        IMASdd.runaway_electrons__ggd_fluid___momentum_critical_avalanche{T},
+        IMASdd.runaway_electrons__ggd_fluid___momentum_critical_hot_tail{T},
+        IMASdd.runaway_electrons__ggd_fluid___pitch_angle{T},
+        IMASdd.tf__field_map___a_field_r{T},
+        IMASdd.tf__field_map___a_field_tor{T},
+        IMASdd.tf__field_map___a_field_z{T},
+        IMASdd.tf__field_map___b_field_r{T},
+        IMASdd.tf__field_map___b_field_tor{T},
+        IMASdd.tf__field_map___b_field_z{T},
+        IMASdd.transport_solver_numerics__boundary_conditions_ggd___current{T},
+        IMASdd.transport_solver_numerics__boundary_conditions_ggd___electrons__energy{
+            T,
+        },
+        IMASdd.transport_solver_numerics__boundary_conditions_ggd___electrons__particles{
+            T,
+        },
+        IMASdd.transport_solver_numerics__boundary_conditions_ggd___ion___energy{T},
+        IMASdd.transport_solver_numerics__boundary_conditions_ggd___ion___particles{T},
+        IMASdd.transport_solver_numerics__boundary_conditions_ggd___ion___state___energy{
+            T,
+        },
+        IMASdd.transport_solver_numerics__boundary_conditions_ggd___ion___state___particles{
+            T,
+        },
+        IMASdd.wall__description_ggd___component___type{T},
+        IMASdd.wall__description_ggd___ggd___a_field{T},
+        IMASdd.wall__description_ggd___ggd___e_field{T},
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__current__emitted{T},
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__current__incident{T},
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__kinetic__electrons__emitted{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__kinetic__electrons__incident{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__kinetic__ion___emitted{T},
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__kinetic__ion___incident{T},
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__kinetic__ion___state___emitted{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__kinetic__ion___state___incident{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__kinetic__neutral___emitted{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__kinetic__neutral___incident{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__kinetic__neutral___state___emitted{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__kinetic__neutral___state___incident{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__radiation__emitted{T},
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__radiation__incident{T},
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__recombination__ion___emitted{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__recombination__ion___incident{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__recombination__ion___state___emitted{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__recombination__ion___state___incident{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__recombination__neutral___emitted{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__recombination__neutral___incident{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__recombination__neutral___state___emitted{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___energy_fluxes__recombination__neutral___state___incident{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___j_total{T},
+        IMASdd.wall__description_ggd___ggd___particle_fluxes__electrons__emitted{T},
+        IMASdd.wall__description_ggd___ggd___particle_fluxes__electrons__incident{T},
+        IMASdd.wall__description_ggd___ggd___particle_fluxes__ion___emitted{T},
+        IMASdd.wall__description_ggd___ggd___particle_fluxes__ion___incident{T},
+        IMASdd.wall__description_ggd___ggd___particle_fluxes__ion___state___emitted{T},
+        IMASdd.wall__description_ggd___ggd___particle_fluxes__ion___state___incident{T},
+        IMASdd.wall__description_ggd___ggd___particle_fluxes__neutral___emitted{T},
+        IMASdd.wall__description_ggd___ggd___particle_fluxes__neutral___incident{T},
+        IMASdd.wall__description_ggd___ggd___particle_fluxes__neutral___state___emitted{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___particle_fluxes__neutral___state___incident{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___phi_potential{T},
+        IMASdd.wall__description_ggd___ggd___power_density{T},
+        IMASdd.wall__description_ggd___ggd___psi{T},
+        IMASdd.wall__description_ggd___ggd___recycling__ion___coefficient{T},
+        IMASdd.wall__description_ggd___ggd___recycling__ion___state___coefficient{T},
+        IMASdd.wall__description_ggd___ggd___recycling__neutral___coefficient{T},
+        IMASdd.wall__description_ggd___ggd___recycling__neutral___state___coefficient{
+            T,
+        },
+        IMASdd.wall__description_ggd___ggd___resistivity{T},
+        IMASdd.wall__description_ggd___ggd___temperature{T},
+        IMASdd.wall__description_ggd___ggd___v_biasing{T},
+        IMASdd.wall__description_ggd___material___grid_subset{T},
+        IMASdd.wall__description_ggd___thickness___grid_subset{T},
+        IMASdd.waves__coherent_wave___full_wave___b_field__bi_normal{T},
+        IMASdd.waves__coherent_wave___full_wave___b_field__normal{T},
+        IMASdd.waves__coherent_wave___full_wave___b_field__parallel{T},
+        IMASdd.waves__coherent_wave___full_wave___e_field__bi_normal{T},
+        IMASdd.waves__coherent_wave___full_wave___e_field__minus{T},
+        IMASdd.waves__coherent_wave___full_wave___e_field__normal{T},
+        IMASdd.waves__coherent_wave___full_wave___e_field__parallel{T},
+        IMASdd.waves__coherent_wave___full_wave___e_field__plus{T},
+        IMASdd.waves__coherent_wave___full_wave___k_perpendicular{T},
+    } where {T};
+
+"""
+    Base.getproperty(@nospecialize(ids::all__grid_ggd), field::Symbol)
+
+This function links all grid_ggd types with each other. If the grid_ggd has a path
+defined to another instance of grid_ggd, this instance would automatically return
+attributed from the referred instance.
+
+Example:
+By setting:
+
+```julia
+ids.radiation.grid_ggd[1].path = "edge_profiles/grid_ggd(1)"
+```
+
+The following will return value stored in `ids.edge_profilesgrid_ggd[1].grid_subset[36]`
+
+```julia
+ids.radiation.grid_ggd[1].grid_subset[36]
+```
+"""
+function Base.getproperty(@nospecialize(ids::all__grid_ggd), field::Symbol)
+    if IMASdd.ismissing(ids, :path) || field == :path
+        return IMASdd.getfield(ids, field)
+    else
+        ref_ids_name = Symbol(split(ids.path, "/")[1])
+        grid_ggd_ind = parse(Int64, split(split(ids.path, "(")[2], ")")[1])
+        ref_ids = IMASdd.getfield(IMASdd.top_dd(ids), ref_ids_name)
+        grid_ggd = IMASdd.getfield(ref_ids, :grid_ggd)
+        return IMASdd.getfield(grid_ggd[grid_ggd_ind], field)
+    end
+end


### PR DESCRIPTION
grid_ggd like structure is very common in IMAS data dictionary and is used in various different sub dictionaries such as edge_profiles, core_profiles, radiation etc.

The functions present in this repo are very general and should be applciable to all these other types as well since the inherent geometry withing the grid_ggd structures remain the same.

The get_types_with function has been improved to take much less time and does not involve creating dummy objects any more. This funciton stably outputs a list of types that are used to create following new union of types:

all__grid_ggd: Union of all grid_ggd types
all__space: Union of all grid_ggd[:].space types
all__grid_subset: Union of all grid_ggd[:].grid_subset types
all__grid_subset_prop: Union of all ggd[:].*** types that have grid_subset_index as a field. These types typically store values corresponding to a particular grid_subset.

The subset tools, interpolations, and recipes have been modified to expand access to all types. It is notable that some functions like get_subset_space() and subset_do() have been changed in signature to take in subset objects and operate on their element array instead of directly taking in the element array. This is a BREAKING change and thus this branch will require version roll up.

Document has been updated as well.

More functions' output types have been fixed.

Note that there is an increased compilation time due to the expansion but execution time remains the same.