### PR TITLE
Quick bug fix: subset_do does not need space kwarg

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IMASggd"
 uuid = "b7b5e640-9b39-4803-84eb-376048795def"
 authors = ["Anchal Gupta <guptaa@fusion.gat.com>"]
-version = "3.0.0"
+version = "3.1.0"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -35,6 +35,8 @@ get_subset_space
 get_grid_subset
 get_subset_boundary_inds
 get_subset_boundary
+get_grid_ggd
+get_space
 subset_do
 get_subset_centers
 project_prop_on_subset!

--- a/src/subset_tools.jl
+++ b/src/subset_tools.jl
@@ -3,6 +3,8 @@ export get_subset_space
 export get_grid_subset
 export get_subset_boundary_inds
 export get_subset_boundary
+export get_grid_ggd
+export get_space
 export subset_do
 export get_subset_centers
 export project_prop_on_subset!
@@ -163,25 +165,42 @@ function get_subset_boundary(
 end
 
 """
+    get_grid_ggd(subset::Union{all__grid_subset, all__space})::all__grid_ggd
+
+Get the parent grid_ggd of a `grid_subset` or `space` object.
+"""
+function get_grid_ggd(subset::Union{all__grid_subset, all__space})::all__grid_ggd
+    return getfield(getfield(subset, :_parent).value, :_parent).value
+end
+
+"""
+    get_space_from_subset(subset::all__grid_subset)::all__space
+
+Get the corresponding space in parent grid_ggd for a grid_subset object.
+"""
+function get_space(subset::all__grid_subset)::all__space
+    grid_ggd = get_grid_ggd(subset)
+    return grid_ggd.space[subset.element[1].object[1].space]
+end
+
+"""
     subset_do(
         set_operator,
         itrs::Vararg{all__grid_subset};
-        space::all__space,
         use_nodes=false,
     )::all__grid_subset
 
 Function to perform any set operation (intersect, union, setdiff etc.) on
 subset.element to generate a list of elements to go to subset object. If use_nodes is
-true, the set operation will be applied on the set of nodes from subset.element, space
-argument is required for this.
+true, the set operation will be applied on the set of nodes from subset.element.
 """
 function subset_do(
     set_operator,
     itrs::Vararg{all__grid_subset};
-    space::all__space,
     use_nodes=false,
 )::all__grid_subset
     if use_nodes
+        space = get_space(itrs[1])
         ele_inds = set_operator(
             [
                 union([
@@ -195,10 +214,10 @@ function subset_do(
         ele_inds = set_operator(
             [[ele.object[1].index for ele ∈ subset.element] for subset ∈ itrs]...,
         )
-        dim = itrs[1][1].object[1].dimension
+        dim = itrs[1].element[1].object[1].dimension
     end
-    ret_subset = typeof(itrs[1][1])()
-    space_number = itrs[1][1].object[1].space
+    ret_subset = typeof(itrs[1])()
+    space_number = itrs[1].element[1].object[1].space
     add_subset_element!(ret_subset, space_number, dim, ele_inds)
     return ret_subset
 end
@@ -404,7 +423,7 @@ Faster deepcopy function for grid_subset object. This function is used to create
 copy of a grid_subset object bypassing several checks performed by IMASdd.
 """
 function deepcopy_subset(subset::all__grid_subset)::all__grid_subset
-    new_subset = all__grid_subset()
+    new_subset = typeof(subset)()
 
     base = getfield(subset, :base)
     new_base = getfield(new_subset, :base)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
-import IMASggd: interp, get_kdtree, project_prop_on_subset!, get_grid_subset
+import IMASggd:
+    interp, get_kdtree, project_prop_on_subset!, get_grid_subset, get_grid_ggd,
+    get_subset_boundary, subset_do, deepcopy_subset
 using IMASdd: IMASdd
 import Statistics: mean
 using Test
@@ -21,6 +23,9 @@ function parse_commandline()
             :action => :store_true),
         ["--interpeqt"],
         Dict(:help => "Test interpolation of equilibrium time slice",
+            :action => :store_true),
+        ["--subset_tools"],
+        Dict(:help => "Test subset tools",
             :action => :store_true),
     )
     args = ArgParse.parse_args(s)
@@ -154,6 +159,59 @@ if args["projection"]
         #     )
         # end
         @test true
+    end
+end
+
+if args["subset_tools"]
+    @testset "test subset_tools" begin
+        grid_ggd = ids.edge_profiles.grid_ggd[1]
+        space = grid_ggd.space[1]
+
+        @test grid_ggd == get_grid_ggd(space)
+
+        subset_core = get_grid_subset(grid_ggd, 22)
+        subset_sol = get_grid_subset(grid_ggd, 23)
+        subset_odr = get_grid_subset(grid_ggd, 24)
+        subset_idr = get_grid_subset(grid_ggd, 25)
+        subset_otarget = get_grid_subset(grid_ggd, 13)
+        subset_itarget = get_grid_subset(grid_ggd, 14)
+
+        subset_corebnd = get_grid_subset(grid_ggd, 15)
+        subset_separatrix = get_grid_subset(grid_ggd, 16)
+        subset_pfrcut = get_grid_subset(grid_ggd, 8)
+        subset_otsep = get_grid_subset(grid_ggd, 103)
+        subset_itsep = get_grid_subset(grid_ggd, 104)
+
+        core_bdry = get_subset_boundary(space, subset_core)
+        sol_bdry = get_subset_boundary(space, subset_sol)
+        idr_bdry = get_subset_boundary(space, subset_idr)
+        odr_bdry = get_subset_boundary(space, subset_odr)
+
+        @test subset_pfrcut.element ==
+              subset_do(intersect, idr_bdry, odr_bdry).element
+        @test subset_corebnd.element ==
+              subset_do(setdiff, core_bdry, sol_bdry).element
+        @test subset_separatrix.element ==
+              subset_do(intersect, sol_bdry,
+            subset_do(union, core_bdry, odr_bdry, idr_bdry)).element
+        @test subset_otsep.element ==
+              subset_do(
+            intersect,
+            subset_separatrix,
+            subset_otarget;
+            use_nodes=true,
+        ).element
+        @test subset_itsep.element ==
+              subset_do(
+            intersect,
+            subset_separatrix,
+            subset_itarget;
+            use_nodes=true,
+        ).element
+
+        sol_copy = deepcopy_subset(subset_sol)
+
+        @test subset_sol == deepcopy_subset(subset_sol)
     end
 end
 


### PR DESCRIPTION
space keyword argument was being used in subset_do when use_nodes was true but this requried unnecessary creation of empty dummy input when use_nodes was not true.

With _parent fields in IMASdd ids, we can actually get the space object corresponding to a grid subset. So new functions have been added to get the parent objects:

get_grid_ggd: gets parent grid_ggd from space or grid_subset
get_space: gets corresponding space of a grid_subset from the parent.

New tests for testing subset_tools have been added as well.

Since the previous 3.0.0 has a bug because of this, minor version has been rolled up.